### PR TITLE
ACF Flexible Content Recursion

### DIFF
--- a/class-fresh-forms-for-gravity.php
+++ b/class-fresh-forms-for-gravity.php
@@ -507,8 +507,10 @@ class Fresh_Forms_For_Gravity extends GFAddOn {
 			if ( true === $this->find_gf_shortcode( $acf_field['value'], 'gform_wrapper' ) ) {
 				return true;
 			}
-		} elseif ( 'wysiwyg' === $acf_field['type'] ) { // Look for a GF class inside a standalone wysiwyg field.
-			if ( true === $this->scan_post_content( $acf_field['value'], 'gform_wrapper' ) ) {
+		} elseif ( 'wysiwyg' === $acf_field['type'] ) { // Look for a GF class or shortcode inside a standalone wysiwyg field.
+			if ( true === $this->find_gf_shortcode( $acf_field['value'] ) ) {
+				return true;
+			} elseif ( true === $this->scan_post_content( $acf_field['value'], 'gform_wrapper' ) ) {
 				return true;
 			}
 		} elseif ( ( 'flexible_content' === $acf_field['type'] || 'repeater' === $acf_field['type'] ) && ! empty( $acf_field['value'])) {

--- a/class-fresh-forms-for-gravity.php
+++ b/class-fresh-forms-for-gravity.php
@@ -542,7 +542,7 @@ class Fresh_Forms_For_Gravity extends GFAddOn {
 					continue;
 				}
 
-				$subfield = get_field_object( $key, $post_id );
+				$subfield = get_sub_field_object( $key );
 				if ( $subfield &&  $this->acf_field_has_gf( $subfield, $post_id )) {
 					return true;
 				}


### PR DESCRIPTION
Makes the ACF field check recursive for flexible content and repeater fields. Also ensures that string-check functions are not used on non-string values by only running them on the appropriate fields.